### PR TITLE
fix: Correct iOS Contents.json for SVG and misc updates

### DIFF
--- a/figma-asset-downloader.config.yaml
+++ b/figma-asset-downloader.config.yaml
@@ -69,15 +69,3 @@ images:
     # - "xhdpi"  # Uncomment to skip xhdpi
     # - "xxhdpi"  # Uncomment to skip xxhdpi
     # - "xxxhdpi"  # Uncomment to skip xxxhdpi
-
-# Configuration for button assets
-buttons:
-  # Android: (SVG -> Android Vector Drawable)
-  # Path where button assets will be saved (default: 'res')
-  # The tool will create a 'drawable' subdirectory in this path
-  path: "app/src/main/res"
-  # path: "Assets.xcassets" # iOS
-
-  # Prefix for button filenames (default: 'button_')
-  # For example, button/home_tab on figma will be downloaded as button_home_tab.xml
-  prefix: "button_"

--- a/figma-asset-downloader.config.yaml
+++ b/figma-asset-downloader.config.yaml
@@ -69,3 +69,16 @@ images:
     # - "xhdpi"  # Uncomment to skip xhdpi
     # - "xxhdpi"  # Uncomment to skip xxhdpi
     # - "xxxhdpi"  # Uncomment to skip xxxhdpi
+
+# Configuration for button assets
+buttons:
+  # Android: (SVG -> Android Vector Drawable)
+  # Path where button assets will be saved (default: 'res')
+  # The tool will create a 'drawable' subdirectory in this path
+  path: "app/src/main/res"
+  # path: "Assets.xcassets" # iOS
+
+  # Prefix for button filenames (default: 'button_')
+  # For example, button/home_tab on figma will be downloaded as button_home_tab.xml
+  prefix: "button_"
+  # prefix: "button_" # iOS

--- a/figma-asset-downloader.config.yaml
+++ b/figma-asset-downloader.config.yaml
@@ -81,4 +81,3 @@ buttons:
   # Prefix for button filenames (default: 'button_')
   # For example, button/home_tab on figma will be downloaded as button_home_tab.xml
   prefix: "button_"
-  # prefix: "button_" # iOS

--- a/src/index.js
+++ b/src/index.js
@@ -756,7 +756,7 @@ async function processIcons(components, fileId, config) {
   // Process each icon
   let iconCounter = 0;
   const totalIcons = iconComponents.length;
-  const processedComponents = new Set(); // Track processed components
+  const processedComponents = new Set();
 
   for (const component of iconComponents) {
     iconCounter++;
@@ -777,13 +777,13 @@ async function processIcons(components, fileId, config) {
           // Convert to vector drawable XML
           const xmlContent = await convertSvgForPlatform(optimizedSvg, 'android');
           const drawablePath = path.join(config.icons.path, 'drawable');
-          await cleanAssetDirectory(drawablePath); // Clean before writing new icon
+          await cleanAssetDirectory(drawablePath);
           const filePath = path.join(drawablePath, `${fileName}.xml`);
           await fs.writeFile(filePath, xmlContent, 'utf8');
         } else {
           // Create asset catalog structure
           const assetPath = path.join(config.icons.path, `${fileName}.imageset`);
-          await cleanAssetDirectory(assetPath); // Clean before writing new icon asset
+          await cleanAssetDirectory(assetPath);
 
           // Save SVG directly for iOS
           const filePath = path.join(assetPath, `${fileName}.svg`);
@@ -796,7 +796,7 @@ async function processIcons(components, fileId, config) {
         }
 
         spinner.succeed(`Icon saved (${iconCounter}/${totalIcons}): ${fileName}`);
-        processedComponents.add(component.id); // Add to processed set on success
+        processedComponents.add(component.id);
       } catch (error) {
         spinner.fail(`Failed to process icon (${iconCounter}/${totalIcons}): ${component.name}`);
         console.error(chalk.red(error.message));
@@ -806,7 +806,7 @@ async function processIcons(components, fileId, config) {
     }
   }
 
-  return processedComponents; // Return the set of processed component IDs
+  return processedComponents;
 }
 
 /**
@@ -824,7 +824,7 @@ async function processImages(components, fileId, config) {
   // Process each image
   let imageCounter = 0;
   const totalImages = imageComponents.length;
-  const processedComponents = new Set(); // Track processed components
+  const processedComponents = new Set();
 
   for (const component of imageComponents) {
     imageCounter++;
@@ -851,7 +851,7 @@ async function processImages(components, fileId, config) {
           for (const dpi of dpisToProcess) {
             const scale = ANDROID_DPI_SCALES[dpi];
             const drawablePath = path.join(config.images.path, `drawable-${dpi}`);
-            await cleanAssetDirectory(drawablePath); // Clean before writing new image
+            await cleanAssetDirectory(drawablePath);
 
             const fileName = `${fileNameBase}.${config.images.format}`;
             const filePath = path.join(drawablePath, fileName);
@@ -870,7 +870,7 @@ async function processImages(components, fileId, config) {
         } else {
           // Create asset catalog structure
           const assetPath = path.join(config.images.path, `${fileNameBase}.imageset`);
-          await cleanAssetDirectory(assetPath); // Clean before writing new image asset
+          await cleanAssetDirectory(assetPath);
 
           // Process for each scale (1x, 2x, 3x)
           for (const [scale, factor] of Object.entries(IOS_SCALES)) {
@@ -894,7 +894,7 @@ async function processImages(components, fileId, config) {
         }
 
         spinner.succeed(`Image saved (${imageCounter}/${totalImages}): ${fileNameBase}`);
-        processedComponents.add(component.id); // Add to processed set on success
+        processedComponents.add(component.id);
       } catch (error) {
         spinner.fail(`Failed to process image (${imageCounter}/${totalImages}): ${component.name}`);
         console.error(chalk.red(error.message));
@@ -904,7 +904,7 @@ async function processImages(components, fileId, config) {
     }
   }
 
-  return processedComponents; // Return the set of processed component IDs
+  return processedComponents;
 }
 
 /**
@@ -922,7 +922,7 @@ async function processButtons(components, fileId, config) {
   // Process each button
   let buttonCounter = 0;
   const totalButtons = buttonComponents.length;
-  const processedComponents = new Set(); // Track processed components
+  const processedComponents = new Set();
 
   for (const component of buttonComponents) {
     buttonCounter++;
@@ -943,13 +943,13 @@ async function processButtons(components, fileId, config) {
           // Convert to vector drawable XML
           const xmlContent = await convertSvgForPlatform(optimizedSvg, 'android');
           const drawablePath = path.join(config.buttons.path, 'drawable');
-          await cleanAssetDirectory(drawablePath); // Clean before writing new button
+          await cleanAssetDirectory(drawablePath);
           const filePath = path.join(drawablePath, `${fileName}.xml`);
           await fs.writeFile(filePath, xmlContent, 'utf8');
         } else {
           // Create asset catalog structure
           const assetPath = path.join(config.buttons.path, `${fileName}.imageset`);
-          await cleanAssetDirectory(assetPath); // Clean before writing new button asset
+          await cleanAssetDirectory(assetPath);
 
           // Save SVG directly for iOS
           const filePath = path.join(assetPath, `${fileName}.svg`);
@@ -962,7 +962,7 @@ async function processButtons(components, fileId, config) {
         }
 
         spinner.succeed(`Button saved (${buttonCounter}/${totalButtons}): ${fileName}`);
-        processedComponents.add(component.id); // Add to processed set on success
+        processedComponents.add(component.id);
       } catch (error) {
         spinner.fail(`Failed to process button (${buttonCounter}/${totalButtons}): ${component.name}`);
         console.error(chalk.red(error.message));
@@ -972,7 +972,7 @@ async function processButtons(components, fileId, config) {
     }
   }
 
-  return processedComponents; // Return the set of processed component IDs
+  return processedComponents;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -830,8 +830,8 @@ async function processImages(components, fileId, config) {
 
   console.log(chalk.yellow(`\nProcessing ${imageComponents.length} images...`));
 
-  // Get PNG URLs for images (we'll convert to webp if needed)
-  const imageUrls = await getImageUrls(fileId, imageComponents, config.images.format, 1, config.platform);
+  // Get PNG URLs for images (we'll convert to the required format if needed)
+  const imageUrls = await getImageUrls(fileId, imageComponents, 'png', 1, config.platform);
 
   // Process each image
   let imageCounter = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -649,21 +649,21 @@ async function processImageForScale(imageBuffer, scale, format, quality, maxScal
 /**
  * Create Contents.json for iOS assets
  */
-function createContentsJson(name, type = 'image') {
+function createContentsJson(name, format = 'png') {
   return JSON.stringify({
     images: [
       {
-        filename: `${name}.png`,
+        filename: `${name}.${format}`,
         idiom: 'universal',
         scale: '1x'
       },
       {
-        filename: `${name}@2x.png`,
+        filename: `${name}@2x.${format}`,
         idiom: 'universal',
         scale: '2x'
       },
       {
-        filename: `${name}@3x.png`,
+        filename: `${name}@3x.${format}`,
         idiom: 'universal',
         scale: '3x'
       }
@@ -749,7 +749,7 @@ async function processIcons(components, fileId, config) {
 
           // Create Contents.json
           const contentsPath = path.join(assetPath, 'Contents.json');
-          const contents = createContentsJson(fileName, 'icon');
+          const contents = createContentsJson(fileName, config.images.format);
           await fs.writeFile(contentsPath, contents, 'utf8');
         }
 
@@ -774,7 +774,7 @@ async function processImages(components, fileId, config) {
   console.log(chalk.yellow(`\nProcessing ${imageComponents.length} images...`));
 
   // Get PNG URLs for images (we'll convert to webp if needed)
-  const imageUrls = await getImageUrls(fileId, imageComponents, 'png', 1, config.platform);
+  const imageUrls = await getImageUrls(fileId, imageComponents, config.images.format, 1, config.platform);
 
   // Process each image
   let imageCounter = 0;
@@ -830,19 +830,19 @@ async function processImages(components, fileId, config) {
             const processedImage = await processImageForScale(
               imageBuffer,
               factor,
-              'png',
+              config.images.format,
               config.images.quality,
               IOS_SCALES['3x']
             );
 
             const scaleFileName = scale === '1x' ? fileNameBase : `${fileNameBase}@${scale}`;
-            const filePath = path.join(assetPath, `${scaleFileName}.png`);
+            const filePath = path.join(assetPath, `${scaleFileName}.${config.images.format}`);
             await fs.writeFile(filePath, processedImage);
           }
 
           // Create Contents.json
           const contentsPath = path.join(assetPath, 'Contents.json');
-          const contents = createContentsJson(fileNameBase);
+          const contents = createContentsJson(fileNameBase, config.images.format);
           await fs.writeFile(contentsPath, contents, 'utf8');
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -756,7 +756,7 @@ async function processIcons(components, fileId, config) {
   // Process each icon
   let iconCounter = 0;
   const totalIcons = iconComponents.length;
-  const processedComponents = new Set();
+  const processedComponentIds = new Set();
 
   for (const component of iconComponents) {
     iconCounter++;
@@ -796,7 +796,7 @@ async function processIcons(components, fileId, config) {
         }
 
         spinner.succeed(`Icon saved (${iconCounter}/${totalIcons}): ${fileName}`);
-        processedComponents.add(component.id);
+        processedComponentIds.add(component.id);
       } catch (error) {
         spinner.fail(`Failed to process icon (${iconCounter}/${totalIcons}): ${component.name}`);
         console.error(chalk.red(error.message));
@@ -806,7 +806,7 @@ async function processIcons(components, fileId, config) {
     }
   }
 
-  return processedComponents;
+  return processedComponentIds;
 }
 
 /**
@@ -824,7 +824,7 @@ async function processImages(components, fileId, config) {
   // Process each image
   let imageCounter = 0;
   const totalImages = imageComponents.length;
-  const processedComponents = new Set();
+  const processedComponentIds = new Set();
 
   for (const component of imageComponents) {
     imageCounter++;
@@ -894,7 +894,7 @@ async function processImages(components, fileId, config) {
         }
 
         spinner.succeed(`Image saved (${imageCounter}/${totalImages}): ${fileNameBase}`);
-        processedComponents.add(component.id);
+        processedComponentIds.add(component.id);
       } catch (error) {
         spinner.fail(`Failed to process image (${imageCounter}/${totalImages}): ${component.name}`);
         console.error(chalk.red(error.message));
@@ -904,7 +904,7 @@ async function processImages(components, fileId, config) {
     }
   }
 
-  return processedComponents;
+  return processedComponentIds;
 }
 
 /**
@@ -933,16 +933,16 @@ async function main() {
     // Fetch components
     const components = await fetchComponents(fileId, componentNames, pageId, pageName);
 
-    // Process icons and images and get their processed component IDs
-    const processedIcons = await processIcons(components, fileId, config);
-    const processedImages = await processImages(components, fileId, config);
+    // Process icons and images
+    const processedIconIds = await processIcons(components, fileId, config);
+    const processedImageIds = await processImages(components, fileId, config);
 
     // Combine all processed component IDs
-    const allProcessedComponents = new Set([...processedIcons, ...processedImages]);
+    const allProcessedComponentIds = new Set([...processedIconIds, ...processedImageIds]);
 
     // Find unprocessed components
     const unprocessedComponents = components.filter(component =>
-      !allProcessedComponents.has(component.id)
+      !allProcessedComponentIds.has(component.id)
     );
 
     if (unprocessedComponents.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -768,7 +768,7 @@ async function processIcons(components, fileId, config) {
   // Process each icon
   let iconCounter = 0;
   const totalIcons = iconComponents.length;
-  const processedComponentIds = new Set();
+  const processedComponentNames = new Set();
 
   for (const component of iconComponents) {
     iconCounter++;
@@ -808,7 +808,7 @@ async function processIcons(components, fileId, config) {
         }
 
         spinner.succeed(`Icon saved (${iconCounter}/${totalIcons}): ${fileName}`);
-        processedComponentIds.add(component.id);
+        processedComponentNames.add(component.name);
       } catch (error) {
         spinner.fail(`Failed to process icon (${iconCounter}/${totalIcons}): ${component.name}`);
         console.error(chalk.red(error.message));
@@ -818,7 +818,7 @@ async function processIcons(components, fileId, config) {
     }
   }
 
-  return processedComponentIds;
+  return processedComponentNames;
 }
 
 /**
@@ -830,13 +830,13 @@ async function processImages(components, fileId, config) {
 
   console.log(chalk.yellow(`\nProcessing ${imageComponents.length} images...`));
 
-  // Get PNG URLs for images (we'll convert to the required format if needed)
+  // Get PNG URLs for images
   const imageUrls = await getImageUrls(fileId, imageComponents, 'png', 1, config.platform);
 
   // Process each image
   let imageCounter = 0;
   const totalImages = imageComponents.length;
-  const processedComponentIds = new Set();
+  const processedComponentNames = new Set();
 
   for (const component of imageComponents) {
     imageCounter++;
@@ -919,7 +919,7 @@ async function processImages(components, fileId, config) {
         }
 
         spinner.succeed(`Image saved (${imageCounter}/${totalImages}): ${fileNameBase}`);
-        processedComponentIds.add(component.id);
+        processedComponentNames.add(component.name);
       } catch (error) {
         spinner.fail(`Failed to process image (${imageCounter}/${totalImages}): ${component.name}`);
         console.error(chalk.red(error.message));
@@ -929,7 +929,7 @@ async function processImages(components, fileId, config) {
     }
   }
 
-  return processedComponentIds;
+  return processedComponentNames;
 }
 
 /**
@@ -959,15 +959,15 @@ async function main() {
     const components = await fetchComponents(fileId, componentNames, pageId, pageName);
 
     // Process icons and images
-    const processedIconIds = await processIcons(components, fileId, config);
-    const processedImageIds = await processImages(components, fileId, config);
+    const processedIconNames = await processIcons(components, fileId, config);
+    const processedImageNames = await processImages(components, fileId, config);
 
-    // Combine all processed component IDs
-    const allProcessedComponentIds = new Set([...processedIconIds, ...processedImageIds]);
+    // Combine all processed component names
+    const allProcessedComponentNames = new Set([...processedIconNames, ...processedImageNames]);
 
     // Find unprocessed components
     const unprocessedComponents = components.filter(component =>
-      !allProcessedComponentIds.has(component.id)
+      !allProcessedComponentNames.has(component.name)
     );
 
     if (unprocessedComponents.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -356,12 +356,6 @@ async function fetchComponents(fileId, componentNames, pageId = '', pageName = '
 
       // Filter to only include exact matches
       filteredComponents = Array.from(nameMap.values());
-
-      // Check if any requested components were not found
-      const notFound = componentNames.filter(name => !nameMap.has(name));
-      if (notFound.length > 0) {
-        console.log(chalk.red(`Warning: The following components were not found: ${notFound.join(', ')}`));
-      }
     } else if (!downloadAll && !sectionName) {
       // This case should not happen due to the help message check at the beginning,
       // but we'll keep it as a safeguard
@@ -966,14 +960,14 @@ async function main() {
     const allProcessedComponentNames = new Set([...processedIconNames, ...processedImageNames]);
 
     // Find unprocessed components
-    const unprocessedComponents = components.filter(component =>
-      !allProcessedComponentNames.has(component.name)
+    const unprocessedComponentNames = componentNames.filter(componentName =>
+      !allProcessedComponentNames.has(componentName)
     );
 
-    if (unprocessedComponents.length > 0) {
+    if (unprocessedComponentNames.length > 0) {
       console.log(chalk.red('\nThe following components were not processed:'));
-      unprocessedComponents.forEach(component => {
-        console.log(chalk.red(`- ${component.name}`));
+      unprocessedComponentNames.forEach(componentName => {
+        console.log(chalk.red(`- ${componentName}`));
       });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -758,7 +758,7 @@ function handleApiError(error) {
  */
 async function processIcons(components, fileId, config) {
   const iconComponents = components.filter(component => component.name.startsWith('icon/'));
-  if (iconComponents.length === 0) return;
+  if (iconComponents.length === 0) return [];
 
   console.log(chalk.yellow(`\nProcessing ${iconComponents.length} icons...`));
 
@@ -826,7 +826,7 @@ async function processIcons(components, fileId, config) {
  */
 async function processImages(components, fileId, config) {
   const imageComponents = components.filter(component => component.name.startsWith('img/'));
-  if (imageComponents.length === 0) return;
+  if (imageComponents.length === 0) return [];
 
   console.log(chalk.yellow(`\nProcessing ${imageComponents.length} images...`));
 

--- a/src/index.js
+++ b/src/index.js
@@ -595,19 +595,6 @@ async function convertSvgForPlatform(svgContent, platform) {
 }
 
 /**
- * Clean specific asset directory before writing new assets
- */
-async function cleanAssetDirectory(assetPath) {
-  try {
-    await fs.ensureDir(assetPath);
-    await fs.emptyDir(assetPath);
-  } catch (error) {
-    console.error(chalk.red(`Error cleaning asset directory ${assetPath}: ${error.message}`));
-    throw error;
-  }
-}
-
-/**
  * Download an image from a URL
  */
 async function downloadImage(url) {
@@ -783,13 +770,14 @@ async function processIcons(components, fileId, config) {
           // Convert to vector drawable XML
           const xmlContent = await convertSvgForPlatform(optimizedSvg, 'android');
           const drawablePath = path.join(config.icons.path, 'drawable');
-          await cleanAssetDirectory(drawablePath);
+          await fs.ensureDir(drawablePath);
           const filePath = path.join(drawablePath, `${fileName}.xml`);
           await fs.writeFile(filePath, xmlContent, 'utf8');
         } else {
           // Create asset catalog structure
           const assetPath = path.join(config.icons.path, `${fileName}.imageset`);
-          await cleanAssetDirectory(assetPath);
+          await fs.ensureDir(assetPath);
+          await fs.emptyDir(assetPath);
 
           // Save SVG directly for iOS
           const filePath = path.join(assetPath, `${fileName}.svg`);
@@ -857,7 +845,7 @@ async function processImages(components, fileId, config) {
           for (const dpi of dpisToProcess) {
             const scale = ANDROID_DPI_SCALES[dpi];
             const drawablePath = path.join(config.images.path, `drawable-${dpi}`);
-            await cleanAssetDirectory(drawablePath);
+            await fs.ensureDir(drawablePath);
 
             const fileName = `${fileNameBase}.${config.images.format}`;
             const filePath = path.join(drawablePath, fileName);
@@ -876,7 +864,8 @@ async function processImages(components, fileId, config) {
         } else {
           // Create asset catalog structure
           const assetPath = path.join(config.images.path, `${fileNameBase}.imageset`);
-          await cleanAssetDirectory(assetPath);
+          await fs.ensureDir(assetPath);
+          await fs.emptyDir(assetPath);
 
           // Process for each scale (1x, 2x, 3x for universal and 1x, 2x for iPad)
           for (const [scale, factor] of Object.entries(IOS_SCALES)) {

--- a/src/index.js
+++ b/src/index.js
@@ -650,6 +650,24 @@ async function processImageForScale(imageBuffer, scale, format, quality, maxScal
  * Create Contents.json for iOS assets
  */
 function createContentsJson(name, format = 'png') {
+  if (format === 'svg') {
+    return JSON.stringify({
+      images: [
+        {
+          filename: `${name}.${format}`,
+          idiom: 'universal'
+        }
+      ],
+      info: {
+        author: 'Figma Asset Downloader',
+        version: 1
+      },
+      properties: {
+        "template-rendering-intent": "original"
+      }
+    }, null, 2);
+  }
+
   return JSON.stringify({
     images: [
       {
@@ -669,8 +687,11 @@ function createContentsJson(name, format = 'png') {
       }
     ],
     info: {
-      author: 'Figma Asset Downloader',
-      version: 1
+      version: 1,
+      author: 'xcode'
+    },
+    properties: {
+      "template-rendering-intent": "original"
     }
   }, null, 2);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -627,7 +627,13 @@ async function downloadImage(url) {
 /**
  * Process an image for a specific scale
  */
-async function processImageForScale(imageBuffer, scale, format, quality, maxScale) {
+async function processImageForScale({
+  imageBuffer,
+  scale,
+  format,
+  quality,
+  maxScale
+}) {
   try {
     // Get the metadata to determine original dimensions
     const metadata = await sharp(imageBuffer).metadata();
@@ -843,13 +849,13 @@ async function processImages(components, fileId, config) {
             const fileName = `${fileNameBase}.${config.images.format}`;
             const filePath = path.join(drawablePath, fileName);
 
-            const processedImage = await processImageForScale(
+            const processedImage = await processImageForScale({
               imageBuffer,
               scale,
-              config.images.format,
-              config.images.quality,
-              ANDROID_DPI_SCALES.xxxhdpi
-            );
+              format: config.images.format,
+              quality: config.images.quality,
+              maxScale: ANDROID_DPI_SCALES.xxxhdpi
+            });
 
             // Save the processed image
             await fs.writeFile(filePath, processedImage);
@@ -861,13 +867,13 @@ async function processImages(components, fileId, config) {
 
           // Process for each scale (1x, 2x, 3x)
           for (const [scale, factor] of Object.entries(IOS_SCALES)) {
-            const processedImage = await processImageForScale(
+            const processedImage = await processImageForScale({
               imageBuffer,
-              factor,
-              config.images.format,
-              config.images.quality,
-              IOS_SCALES['3x']
-            );
+              scale: factor,
+              format: config.images.format,
+              quality: config.images.quality,
+              maxScale: IOS_SCALES['3x']
+            });
 
             const scaleFileName = scale === '1x' ? fileNameBase : `${fileNameBase}@${scale}`;
             const filePath = path.join(assetPath, `${scaleFileName}.${config.images.format}`);

--- a/src/index.js
+++ b/src/index.js
@@ -599,6 +599,19 @@ async function convertSvgForPlatform(svgContent, platform) {
 }
 
 /**
+ * Clean specific asset directory before writing new assets
+ */
+async function cleanAssetDirectory(assetPath) {
+  try {
+    await fs.ensureDir(assetPath);
+    await fs.emptyDir(assetPath);
+  } catch (error) {
+    console.error(chalk.red(`Error cleaning asset directory ${assetPath}: ${error.message}`));
+    throw error;
+  }
+}
+
+/**
  * Download an image from a URL
  */
 async function downloadImage(url) {
@@ -756,13 +769,13 @@ async function processIcons(components, fileId, config) {
           // Convert to vector drawable XML
           const xmlContent = await convertSvgForPlatform(optimizedSvg, 'android');
           const drawablePath = path.join(config.icons.path, 'drawable');
-          await fs.ensureDir(drawablePath);
+          await cleanAssetDirectory(drawablePath); // Clean before writing new icon
           const filePath = path.join(drawablePath, `${fileName}.xml`);
           await fs.writeFile(filePath, xmlContent, 'utf8');
         } else {
           // Create asset catalog structure
           const assetPath = path.join(config.icons.path, `${fileName}.imageset`);
-          await fs.ensureDir(assetPath);
+          await cleanAssetDirectory(assetPath); // Clean before writing new icon asset
 
           // Save SVG directly for iOS
           const filePath = path.join(assetPath, `${fileName}.svg`);
@@ -825,7 +838,7 @@ async function processImages(components, fileId, config) {
           for (const dpi of dpisToProcess) {
             const scale = ANDROID_DPI_SCALES[dpi];
             const drawablePath = path.join(config.images.path, `drawable-${dpi}`);
-            await fs.ensureDir(drawablePath);
+            await cleanAssetDirectory(drawablePath); // Clean before writing new image
 
             const fileName = `${fileNameBase}.${config.images.format}`;
             const filePath = path.join(drawablePath, fileName);
@@ -844,7 +857,7 @@ async function processImages(components, fileId, config) {
         } else {
           // Create asset catalog structure
           const assetPath = path.join(config.images.path, `${fileNameBase}.imageset`);
-          await fs.ensureDir(assetPath);
+          await cleanAssetDirectory(assetPath); // Clean before writing new image asset
 
           // Process for each scale (1x, 2x, 3x)
           for (const [scale, factor] of Object.entries(IOS_SCALES)) {

--- a/src/index.js
+++ b/src/index.js
@@ -908,6 +908,74 @@ async function processImages(components, fileId, config) {
 }
 
 /**
+ * Process and save buttons from Figma components
+ */
+async function processButtons(components, fileId, config) {
+  const buttonComponents = components.filter(component => component.name.startsWith('button/'));
+  if (buttonComponents.length === 0) return;
+
+  console.log(chalk.yellow(`\nProcessing ${buttonComponents.length} buttons...`));
+
+  // Get SVG URLs for buttons
+  const buttonUrls = await getImageUrls(fileId, buttonComponents, 'svg', 1, config.platform);
+
+  // Process each button
+  let buttonCounter = 0;
+  const totalButtons = buttonComponents.length;
+  const processedComponents = new Set(); // Track processed components
+
+  for (const component of buttonComponents) {
+    buttonCounter++;
+    const imageUrl = buttonUrls[component.id];
+    if (imageUrl) {
+      const spinner = ora(`Processing button (${buttonCounter}/${totalButtons}): ${component.name}`).start();
+      try {
+        // Extract the button name from the component name (remove 'button/' prefix)
+        const buttonName = component.name.replace('button/', '');
+        const sanitizedName = buttonName.replace(/\s+/g, '_').toLowerCase();
+        const fileName = `${config.buttons.prefix}${sanitizedName}`;
+
+        // Download and process the SVG
+        const svgContent = await downloadSvg(imageUrl);
+        const optimizedSvg = await optimizeSvg(svgContent);
+
+        if (config.platform === 'android') {
+          // Convert to vector drawable XML
+          const xmlContent = await convertSvgForPlatform(optimizedSvg, 'android');
+          const drawablePath = path.join(config.buttons.path, 'drawable');
+          await cleanAssetDirectory(drawablePath); // Clean before writing new button
+          const filePath = path.join(drawablePath, `${fileName}.xml`);
+          await fs.writeFile(filePath, xmlContent, 'utf8');
+        } else {
+          // Create asset catalog structure
+          const assetPath = path.join(config.buttons.path, `${fileName}.imageset`);
+          await cleanAssetDirectory(assetPath); // Clean before writing new button asset
+
+          // Save SVG directly for iOS
+          const filePath = path.join(assetPath, `${fileName}.svg`);
+          await fs.writeFile(filePath, optimizedSvg, 'utf8');
+
+          // Create Contents.json
+          const contentsPath = path.join(assetPath, 'Contents.json');
+          const contents = createContentsJson(fileName, 'svg');
+          await fs.writeFile(contentsPath, contents, 'utf8');
+        }
+
+        spinner.succeed(`Button saved (${buttonCounter}/${totalButtons}): ${fileName}`);
+        processedComponents.add(component.id); // Add to processed set on success
+      } catch (error) {
+        spinner.fail(`Failed to process button (${buttonCounter}/${totalButtons}): ${component.name}`);
+        console.error(chalk.red(error.message));
+      }
+    } else {
+      console.error(chalk.red(`No image URL found for button (${buttonCounter}/${totalButtons}): ${component.name}`));
+    }
+  }
+
+  return processedComponents; // Return the set of processed component IDs
+}
+
+/**
  * Main function to run the application
  */
 async function main() {
@@ -933,12 +1001,17 @@ async function main() {
     // Fetch components
     const components = await fetchComponents(fileId, componentNames, pageId, pageName);
 
-    // Process icons and images and get their processed component IDs
+    // Process icons, images, and buttons and get their processed component IDs
     const processedIcons = await processIcons(components, fileId, config);
     const processedImages = await processImages(components, fileId, config);
+    const processedButtons = await processButtons(components, fileId, config);
 
     // Combine all processed component IDs
-    const allProcessedComponents = new Set([...processedIcons, ...processedImages]);
+    const allProcessedComponents = new Set([
+      ...processedIcons,
+      ...processedImages,
+      ...processedButtons
+    ]);
 
     // Find unprocessed components
     const unprocessedComponents = components.filter(component =>


### PR DESCRIPTION
This PR addresses issues with iOS asset generation:

- Add `cleanAssetDirectory` function to prevent asset conflicts
- Refactor `processImageForScale` to use named parameters
- Revise `createContentsJson` to support different formats (png/svg)
- Add tracking of processed components to identify unprocessed ones
- Change warning for missing components from yellow to red text

This improves iOS asset export workflow and provides better error visibility.

# Testing Steps

```sh
FIGMA_TOKEN="67747-b4795e9e-26fd-4f69-b538-ac7dec5babac" node src/index.js icon/verified button/arrow_blue img/illustration_afterlogin img/ani_wiggle
```