### PR TITLE
fix: Download scaled images rather than scaling locally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -514,23 +514,22 @@ function traverseNode(node, callback, path = [], depth = 0) {
  * Get image URLs for components
  */
 async function getImageUrls(fileId, components, format = 'svg', scale = 1, platform) {
-  const spinner = ora('Getting image URLs from Figma...').start();
+  const spinner = ora(`Getting image URLs from Figma (format: ${format}, scale: ${scale})...`).start();
 
   try {
     const componentIds = components.map(component => component.id).join(',');
     // Request the highest scale for images to ensure high quality
-    const scaleParam = format === 'png' ? (platform === 'android' ? 4 : 3) : scale;
-    const response = await figmaApi.get(`/images/${fileId}?ids=${componentIds}&format=${format}&scale=${scaleParam}`);
+    const response = await figmaApi.get(`/images/${fileId}?ids=${componentIds}&format=${format}&scale=${scale}`);
 
     if (!response.data.images) {
-      spinner.fail('No image URLs returned from Figma API');
+      spinner.fail(`No image URLs returned from Figma API (format: ${format}, scale: ${scale})`);
       process.exit(1);
     }
 
-    spinner.succeed('Successfully retrieved image URLs');
+    spinner.succeed(`Successfully retrieved image URLs (format: ${format}, scale: ${scale})`);
     return response.data.images;
   } catch (error) {
-    spinner.fail('Error getting image URLs from Figma');
+    spinner.fail(`Error getting image URLs from Figma (format: ${format}, scale: ${scale})`);
     handleApiError(error);
     process.exit(1);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -934,7 +934,8 @@ async function main() {
     if (unprocessedComponentNames.length > 0) {
       console.log(chalk.red('\nThe following components were not processed:'));
       unprocessedComponentNames.forEach(componentName => {
-        console.log(chalk.red(`- ${componentName}`));
+        const componentExists = components.some(c => c.name === componentName);
+        console.log(chalk.red(`- ${componentName}${!componentExists ? ' (not found)' : ''}`));
       });
     }
 


### PR DESCRIPTION
Download images at their correct scale directly from Figma API instead of resizing locally.

- Request proper scale directly from API
- Avoid local resizing
- Preserve quality
- Better logging

## Testing Steps

With `platform=android|ios` run:
```sh
FIGMA_TOKEN="67747-b4795e9e-26fd-4f69-b538-ac7dec5babac" node src/index.js icon/verified button/arrow_blue img/illustration_afterlogin img/ani_wigglegit git lg icon/warmth icon/contrast
```

## Screenshots
|Android|
|-|
|![Screenshot 2025-05-15 at 8 10 05 PM](https://github.com/user-attachments/assets/bf9be079-f4f4-4923-afde-405d5010c2ca)|
|iOS|
|![Screenshot 2025-05-15 at 8 10 10 PM](https://github.com/user-attachments/assets/3547f5aa-e876-4107-b4bc-045df81e7897)|


🤖 Generated with [Claude Code](https://claude.ai/code)